### PR TITLE
Removed redundant mention of the median

### DIFF
--- a/src/lib/decide_estimate.ts
+++ b/src/lib/decide_estimate.ts
@@ -77,12 +77,12 @@ export function decideEstimate(votes: Fib[]): Decision {
     }
     // small gap → median
     return {kind:'final', points: med,
-      reason:`There are two clusters close together; use median: ${med}.`};
+      reason:`There are two clusters close together; use median.`};
   }
 
   // Risk-aware median
   if (spread <= 2) {
-    return {kind:'final', points: med, reason:`Low spread; usemedian ${med}.`};
+    return {kind:'final', points: med, reason:`Low spread; use median.`};
   }
   if (spread <= 3) {
     const up = nextFibAbove(med);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the explanatory text shown when estimates finalize in bimodal and risk-aware median scenarios. Messages no longer include embedded numeric values and now use generic phrasing.
  * User-visible copy is clearer and more consistent; only the wording changed.
  * No changes to how estimates are calculated or selected—the final points remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->